### PR TITLE
Fixed Erroneous Failure Message

### DIFF
--- a/fru.c
+++ b/fru.c
@@ -614,7 +614,7 @@ struct FRU_DATA * parse_FRU (unsigned char *data)
 
 	/* Parse Chassis Info Area */
 	if (data[4]) {
-		printf_err("Chassis Info Area parsing not yet implemented - sorry\n");
+		printf_err("Product Info Area parsing not yet implemented - sorry\n");
 		goto err;
 	}
 


### PR DESCRIPTION
0x04 should be the Product Info Area, not the Chassis Info Area - updated message to fix this.