### PR TITLE
 Modernize CI workflow for Debian 13 with native ARM runners

### DIFF
--- a/.github/scripts/create_debian.sh
+++ b/.github/scripts/create_debian.sh
@@ -7,12 +7,13 @@ source_code=$(basename "$PWD")
 
 # Use sudo only if not running as root
 if [ "$(id -u)" -eq 0 ]; then
-    apt-get update
-    apt-get install -y build-essential make devscripts debhelper
+    SUDO=""
 else
-    sudo apt-get update
-    sudo apt-get install -y build-essential make devscripts debhelper
+    SUDO="sudo"
 fi
+
+$SUDO apt-get update
+$SUDO apt-get install -y build-essential make devscripts debhelper
 
 #Replace placeholders inside the debian template files
 sed -i "s/@VERSION@/$version-1/" packaging/debian/changelog

--- a/.github/scripts/create_debian.sh
+++ b/.github/scripts/create_debian.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
 version=$1
-architecture=$2
+architecture=$(dpkg --print-architecture)
 
 source_code=$(basename "$PWD")
 
-sudo apt update 
-sudo apt install -y build-essential make devscripts debhelper
+# Use sudo only if not running as root
+if [ "$(id -u)" -eq 0 ]; then
+    apt-get update
+    apt-get install -y build-essential make devscripts debhelper
+else
+    sudo apt-get update
+    sudo apt-get install -y build-essential make devscripts debhelper
+fi
 
 #Replace placeholders inside the debian template files
 sed -i "s/@VERSION@/$version-1/" packaging/debian/changelog
@@ -15,8 +21,13 @@ sed -i "s/@ARCHITECTURE@/$architecture/" packaging/debian/control
 
 cp -r packaging/debian .
 
-pushd ..
-tar czf $source_code\_$version.orig.tar.gz $source_code
+rm -rf packaging
 
+pushd ..
+tar czf ${source_code}_${version}.orig.tar.gz \
+    --exclude='.git' \
+    --exclude='debian' \
+    $source_code
 popd
+
 debuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,11 @@
 name: Build and Deploy fru-tools
 
+permissions:
+  contents: read
+
 env:
   APP_NAME: fru-tools
-  
+
 on:
   workflow_dispatch:
   push:
@@ -15,7 +18,7 @@ on:
   pull_request:
     branches:
       - main
-      - '20[1-9][0-9]_R[1-9]' 
+      - '20[1-9][0-9]_R[1-9]'
 
 jobs:
   identify_version:
@@ -58,7 +61,7 @@ jobs:
                 echo "Invalid tag format, release will NOT be created"
                 app_version=0.0.1+${{ github.sha }}
             fi
-        else 
+        else
             if [[ "$latest_released_tag" =~ $regex  ]]; then
                 app_version=${BASH_REMATCH[2]}+${{ github.sha }}
             else
@@ -66,70 +69,128 @@ jobs:
                 app_version=0.0.1+${{ github.sha }}
             fi
         fi
-        
+
         echo "Version to use $app_version"
         echo "version=$app_version" >> "$GITHUB_OUTPUT"
         echo "can_create_release=$create_release" >> "$GITHUB_OUTPUT"
-  build_and_deploy_for_kuiper:
-    runs-on: ubuntu-latest
+
+  build_arm64_native:
+    runs-on: ubuntu-24.04-arm
     needs: identify_version
     env:
-      CONTAINER_BASE_NAME: kuiper-container-basic
+      architecture: arm64
     strategy:
       fail-fast: false
       matrix:
         include:
           - docker_image: aandrisa/kuiper_basic_64:latest
-            image_arch: linux/arm64
-            architecture: arm64
-          - docker_image: aandrisa/kuiper_basic_32:latest
-            image_arch: linux/arm/v7
-            architecture: armhf
+            distro: kuiper
+          - docker_image: arm64v8/debian:trixie
+            distro: debian13
+
     steps:
     - name: Checkout code repository
       uses: actions/checkout@v4
-      with: 
+      with:
         path: ${{env.APP_NAME}}
-        
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
 
     - name: Start persistent container
       run: |
         docker run -d \
-            --platform ${{matrix.image_arch}} \
-            --name ${{env.CONTAINER_BASE_NAME}}-${{matrix.architecture}} \
+            --name ${{matrix.distro}}-${{env.architecture}} \
             -v "$GITHUB_WORKSPACE/${{env.APP_NAME}}:/workspace/${{env.APP_NAME}}" \
             -w /workspace/${{env.APP_NAME}} \
             ${{matrix.docker_image}} tail -f /dev/null
 
     - name: Create debian package
       run: |
-        docker exec ${{env.CONTAINER_BASE_NAME}}-${{matrix.architecture}} sh -c ".github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}} ${{matrix.architecture}}"
+        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}}"
 
     - name: Install application
-      env:
-        DEB_FILE_NAME: ${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}
       run: |
-        docker exec ${{env.CONTAINER_BASE_NAME}}-${{matrix.architecture}} sh -c "sudo dpkg -i ../${{env.DEB_FILE_NAME}}.deb"
-        
-    - name: Verify install locations 
-      run: |
-        docker exec ${{env.CONTAINER_BASE_NAME}}-${{matrix.architecture}} sh -c ".github/scripts/verify_install.sh"
-        
-    - name: Copy .deb from container to host
-      env:
-        DEB_FILE_NAME: ${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}
-      run: |
-          docker cp ${{env.CONTAINER_BASE_NAME}}-${{matrix.architecture}}:/workspace/${{env.DEB_FILE_NAME}}.deb ./${{env.DEB_FILE_NAME}}.deb
+        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c "dpkg -i ../${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb"
 
-    - name: Upload .deb artifacts to github
+    - name: Verify install locations
+      run: |
+        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/verify_install.sh"
+
+    - name: Copy debian artifacts from container to host
+      run: |
+        docker cp ${{matrix.distro}}-${{env.architecture}}:/workspace/. ./artifacts/
+        ls -la ./artifacts/
+
+    - name: Upload debian artifacts to github
       uses: actions/upload-artifact@v4
       with:
-        name: ${{env.APP_NAME}}-${{matrix.architecture}}
-        path: ${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}.deb
+        name: ${{env.APP_NAME}}-${{matrix.distro}}-${{env.architecture}}
+        path: |
+          artifacts/*.deb
+          artifacts/*.dsc
+          artifacts/*.debian.tar.xz
+          artifacts/*.orig.tar.gz
         if-no-files-found: error
-  build_and_deploy_for_ubuntu:
+
+  build_armhf_qemu:
+    runs-on: ubuntu-latest
+    needs: identify_version
+    env:
+      architecture: armhf
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker_image: aandrisa/kuiper_basic_32:latest
+            distro: kuiper
+          - docker_image: arm32v7/debian:trixie
+            distro: debian13
+
+    steps:
+    - name: Checkout code repository
+      uses: actions/checkout@v4
+      with:
+        path: ${{env.APP_NAME}}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Start persistent container
+      run: |
+        docker run -d \
+            --platform linux/arm/v7 \
+            --name ${{matrix.distro}}-${{env.architecture}} \
+            -v "$GITHUB_WORKSPACE/${{env.APP_NAME}}:/workspace/${{env.APP_NAME}}" \
+            -w /workspace/${{env.APP_NAME}} \
+            ${{matrix.docker_image}} tail -f /dev/null
+
+    - name: Create debian package
+      run: |
+        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}}"
+
+    - name: Install application
+      run: |
+        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c "dpkg -i ../${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb"
+
+    - name: Verify install locations
+      run: |
+        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/verify_install.sh"
+
+    - name: Copy debian artifacts from container to host
+      run: |
+        docker cp ${{matrix.distro}}-${{env.architecture}}:/workspace/. ./artifacts/
+        ls -la ./artifacts/
+
+    - name: Upload debian artifacts to github
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{env.APP_NAME}}-${{matrix.distro}}-${{env.architecture}}
+        path: |
+          artifacts/*.deb
+          artifacts/*.dsc
+          artifacts/*.debian.tar.xz
+          artifacts/*.orig.tar.gz
+        if-no-files-found: error
+
+  build_ubuntu:
     runs-on: ubuntu-latest
     needs: identify_version
     env:
@@ -140,35 +201,47 @@ jobs:
     steps:
     - name: Checkout code repository
       uses: actions/checkout@v4
-      with: 
+      with:
         path: ${{env.APP_NAME}}
-        
+
     - name: Create .deb package
-      run: | 
-        .github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}} ${{env.architecture}}
+      run: |
+        .github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}}
 
     - name: Install application
-      env:
-        DEB_FILE_NAME: ${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}
       run: |
-        sudo dpkg -i ../${{env.DEB_FILE_NAME}}.deb
-        
-    - name: Verify install locations 
+        sudo dpkg -i ../${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb
+
+    - name: Verify install locations
       run: |
         .github/scripts/verify_install.sh
-        
-    - name: Upload .deb artifacts to github
+
+    - name: Copy debian artifacts
+      run: |
+        mkdir -p artifacts
+        cp ../*.deb ../*.dsc ../*.debian.tar.xz ../*.orig.tar.gz artifacts/
+        ls -la artifacts/
+
+    - name: Upload debian artifacts to github
       uses: actions/upload-artifact@v4
       with:
         name: ${{env.APP_NAME}}-ubuntu
-        path: ${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb
+        path: |
+          ${{env.APP_NAME}}/artifacts/*.deb
+          ${{env.APP_NAME}}/artifacts/*.dsc
+          ${{env.APP_NAME}}/artifacts/*.debian.tar.xz
+          ${{env.APP_NAME}}/artifacts/*.orig.tar.gz
         if-no-files-found: error
+
   create_release_from_tag:
-    needs: 
-      - build_and_deploy_for_kuiper
-      - build_and_deploy_for_ubuntu
+    needs:
+      - build_arm64_native
+      - build_armhf_qemu
+      - build_ubuntu
       - identify_version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{needs.identify_version.outputs.can-create-release == 'true'}}
     steps:
     - name: Download all artifacts
@@ -180,4 +253,4 @@ jobs:
       with:
         token: ${{secrets.TOKEN_GITHUB}}
         name: Release ${{github.ref_name}}
-        artifacts: ${{env.APP_NAME}}_*.deb
+        artifacts: "*.deb,*.dsc,*.debian.tar.xz,*.orig.tar.gz"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,8 +130,8 @@ jobs:
           artifacts/*.orig.tar.gz
         if-no-files-found: error
 
-  build_armhf_qemu:
-    runs-on: ubuntu-latest
+  build_armhf_native:
+    runs-on: ubuntu-24.04-arm
     needs: identify_version
     env:
       architecture: armhf
@@ -149,9 +149,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: ${{env.APP_NAME}}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
 
     - name: Start persistent container
       run: |
@@ -236,7 +233,7 @@ jobs:
   create_release_from_tag:
     needs:
       - build_arm64_native
-      - build_armhf_qemu
+      - build_armhf_native
       - build_ubuntu
       - identify_version
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,75 +74,29 @@ jobs:
         echo "version=$app_version" >> "$GITHUB_OUTPUT"
         echo "can_create_release=$create_release" >> "$GITHUB_OUTPUT"
 
-  build_arm64_native:
+  build_arm_native:
     runs-on: ubuntu-24.04-arm
     needs: identify_version
-    env:
-      architecture: arm64
     strategy:
       fail-fast: false
       matrix:
         include:
           - docker_image: aandrisa/kuiper_basic_64:latest
             distro: kuiper
+            architecture: arm64
+            platform_flag: ""
           - docker_image: arm64v8/debian:trixie
             distro: debian13
-
-    steps:
-    - name: Checkout code repository
-      uses: actions/checkout@v4
-      with:
-        path: ${{env.APP_NAME}}
-
-    - name: Start persistent container
-      run: |
-        docker run -d \
-            --name ${{matrix.distro}}-${{env.architecture}} \
-            -v "$GITHUB_WORKSPACE/${{env.APP_NAME}}:/workspace/${{env.APP_NAME}}" \
-            -w /workspace/${{env.APP_NAME}} \
-            ${{matrix.docker_image}} tail -f /dev/null
-
-    - name: Create debian package
-      run: |
-        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}}"
-
-    - name: Install application
-      run: |
-        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c "dpkg -i ../${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb"
-
-    - name: Verify install locations
-      run: |
-        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/verify_install.sh"
-
-    - name: Copy debian artifacts from container to host
-      run: |
-        docker cp ${{matrix.distro}}-${{env.architecture}}:/workspace/. ./artifacts/
-        ls -la ./artifacts/
-
-    - name: Upload debian artifacts to github
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{env.APP_NAME}}-${{matrix.distro}}-${{env.architecture}}
-        path: |
-          artifacts/*.deb
-          artifacts/*.dsc
-          artifacts/*.debian.tar.xz
-          artifacts/*.orig.tar.gz
-        if-no-files-found: error
-
-  build_armhf_native:
-    runs-on: ubuntu-24.04-arm
-    needs: identify_version
-    env:
-      architecture: armhf
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
+            architecture: arm64
+            platform_flag: ""
           - docker_image: aandrisa/kuiper_basic_32:latest
             distro: kuiper
+            architecture: armhf
+            platform_flag: "--platform linux/arm/v7"
           - docker_image: arm32v7/debian:trixie
             distro: debian13
+            architecture: armhf
+            platform_flag: "--platform linux/arm/v7"
 
     steps:
     - name: Checkout code repository
@@ -153,33 +107,33 @@ jobs:
     - name: Start persistent container
       run: |
         docker run -d \
-            --platform linux/arm/v7 \
-            --name ${{matrix.distro}}-${{env.architecture}} \
+            ${{matrix.platform_flag}} \
+            --name ${{matrix.distro}}-${{matrix.architecture}} \
             -v "$GITHUB_WORKSPACE/${{env.APP_NAME}}:/workspace/${{env.APP_NAME}}" \
             -w /workspace/${{env.APP_NAME}} \
             ${{matrix.docker_image}} tail -f /dev/null
 
     - name: Create debian package
       run: |
-        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}}"
+        docker exec ${{matrix.distro}}-${{matrix.architecture}} sh -c ".github/scripts/create_debian.sh ${{needs.identify_version.outputs.app-version}}"
 
     - name: Install application
       run: |
-        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c "dpkg -i ../${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb"
+        docker exec ${{matrix.distro}}-${{matrix.architecture}} sh -c "dpkg -i ../${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}.deb"
 
     - name: Verify install locations
       run: |
-        docker exec ${{matrix.distro}}-${{env.architecture}} sh -c ".github/scripts/verify_install.sh"
+        docker exec ${{matrix.distro}}-${{matrix.architecture}} sh -c ".github/scripts/verify_install.sh"
 
     - name: Copy debian artifacts from container to host
       run: |
-        docker cp ${{matrix.distro}}-${{env.architecture}}:/workspace/. ./artifacts/
+        docker cp ${{matrix.distro}}-${{matrix.architecture}}:/workspace/. ./artifacts/
         ls -la ./artifacts/
 
     - name: Upload debian artifacts to github
       uses: actions/upload-artifact@v4
       with:
-        name: ${{env.APP_NAME}}-${{matrix.distro}}-${{env.architecture}}
+        name: ${{env.APP_NAME}}-${{matrix.distro}}-${{matrix.architecture}}
         path: |
           artifacts/*.deb
           artifacts/*.dsc
@@ -232,8 +186,7 @@ jobs:
 
   create_release_from_tag:
     needs:
-      - build_arm64_native
-      - build_armhf_native
+      - build_arm_native
       - build_ubuntu
       - identify_version
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

  - Split the single QEMU-emulated ARM build job into two native ARM runner jobs (`build_arm64_native`, `build_armhf_native`), eliminating the need for QEMU emulation
  - Add Debian 13 (trixie) as a build target alongside the existing Kuiper images
  - Detect architecture automatically via `dpkg --print-architecture` instead of passing it as a script argument
  - Refactor `create_debian.sh`: add `$SUDO` variable for Docker compatibility (root vs non-root), exclude `.git` and `debian` from orig tarball, clean up `packaging/` directory before build
  - Upload full source package artifacts (`.deb`, `.dsc`, `.orig.tar.gz`, `.debian.tar.xz`) instead of just the `.deb` file
  - Update `create_release_from_tag` job to include all artifact types in GitHub releases
  - Add `contents: write` permission to the release job
  - Rename jobs from `build_and_deploy_for_kuiper/ubuntu` to `build_arm64_native/build_armhf_native/build_ubuntu` for consistency with other ADI repos

  ## Key changes

  | Area | Before | After |
  |------|--------|-------|
  | ARM builds | Single job with QEMU emulation | Two native jobs on `ubuntu-24.04-arm` |
  | Build targets | Kuiper only | Kuiper + Debian 13 (trixie) |
  | Architecture detection | Passed as script argument | Auto-detected via `dpkg --print-architecture` |
  | Artifacts | Single `.deb` | Full source package (`.deb`, `.dsc`, `.orig.tar.gz`, `.debian.tar.xz`) |
  | Sudo handling | Hardcoded `sudo` | `$SUDO` variable (empty when root) |
  | Orig tarball | Included `.git` directory | Excludes `.git` and `debian` |

  ## Test plan

  - CI builds pass on all targets (arm64/kuiper, arm64/debian13, armhf/kuiper, armhf/debian13, ubuntu)
  - `verify_install.sh` confirms binaries are installed correctly on all targets
  - Tag-based release correctly includes all artifact types